### PR TITLE
Feature/ellie examples

### DIFF
--- a/showcase/src/elm/Routes/ButtonComponent.elm
+++ b/showcase/src/elm/Routes/ButtonComponent.elm
@@ -170,7 +170,7 @@ typeExample model =
         metaInfo =
             { title = "Type"
             , content = "There are \"primary\", \"default\", \"dashed\", \"text\" and \"link\" buttons in Elm Antd."
-            , ellieDemo = "https://ellie-app.com/9mhLFFTMgzTa1"
+            , ellieDemo = "https://ellie-app.com/9mjDjrRz2dBa1"
             , sourceCode = typeExampleStr
             }
 
@@ -192,7 +192,7 @@ disabledExample model =
         metaInfo =
             { title = "Disabled"
             , content = "You can disable any button"
-            , ellieDemo = "https://ellie-app.com/9mj25Y2hXXya1"
+            , ellieDemo = "https://ellie-app.com/9mjF8c8DLyTa1"
             , sourceCode = disabledExampleStr
             }
 

--- a/showcase/src/elm/Routes/ButtonComponent.elm
+++ b/showcase/src/elm/Routes/ButtonComponent.elm
@@ -170,7 +170,7 @@ typeExample model =
         metaInfo =
             { title = "Type"
             , content = "There are \"primary\", \"default\", \"dashed\", \"text\" and \"link\" buttons in Elm Antd."
-            , ellieDemo = "https://ellie-app.com/9jQvNFNtj8Fa1"
+            , ellieDemo = "https://ellie-app.com/9mhLFFTMgzTa1"
             , sourceCode = typeExampleStr
             }
 
@@ -192,7 +192,7 @@ disabledExample model =
         metaInfo =
             { title = "Disabled"
             , content = "You can disable any button"
-            , ellieDemo = "https://ellie-app.com/9jQvNFNtj8Fa1"
+            , ellieDemo = "https://ellie-app.com/9mj25Y2hXXya1"
             , sourceCode = disabledExampleStr
             }
 

--- a/showcase/src/elm/Routes/TooltipComponent.elm
+++ b/showcase/src/elm/Routes/TooltipComponent.elm
@@ -93,7 +93,7 @@ basicExample model =
         metaInfo =
             { title = "Basic"
             , content = "The simplest usage."
-            , ellieDemo = "https://ellie-app.com/9jQvNFNtj8Fa1"
+            , ellieDemo = "https://ellie-app.com/9mjyZ2xHwN9a1"
             , sourceCode = basicExampleStr
             }
 

--- a/showcase/src/elm/Routes/TypographyComponent.elm
+++ b/showcase/src/elm/Routes/TypographyComponent.elm
@@ -123,7 +123,7 @@ basicExample model =
         metaInfo =
             { title = "Basic"
             , content = "A document sample"
-            , ellieDemo = "https://ellie-app.com/9jQvNFNtj8Fa1"
+            , ellieDemo = "https://ellie-app.com/9mHk3JkJXSza1"
             , sourceCode = basicExampleStr
             }
 
@@ -168,7 +168,7 @@ titleComponentExample model =
         metaInfo =
             { title = "Title Component"
             , content = "Display the various levels for titles"
-            , ellieDemo = "https://ellie-app.com/9jQvNFNtj8Fa1"
+            , ellieDemo = "https://ellie-app.com/9mHmQ7FdJsSa1"
             , sourceCode = titleComponentStr
             }
 
@@ -203,6 +203,20 @@ example =
             |> Text.textType Warning
         , text "Ant Design"
             |> Text.textType Danger
+        , text "Ant Design"
+            |> Text.disabled True
+        , text "Ant Design"
+            |> Text.highlighted True
+        , text "Ant Design"
+            |> Text.code
+        , text "Ant Design"
+            |> Text.keyboard
+        , text "Ant Design"
+            |> Text.underlined True
+        , text "Ant Design"
+            |> Text.lineThrough True
+        , text "Ant Design"
+            |> Text.strong
         ]
 
 """
@@ -217,7 +231,7 @@ textComponentExample model =
         metaInfo =
             { title = "Text and Link Component"
             , content = "Provides multiple types of text and link."
-            , ellieDemo = "https://ellie-app.com/9jQvNFNtj8Fa1"
+            , ellieDemo = "https://ellie-app.com/9mHyDsVVZk6a1"
             , sourceCode = texComponentStr
             }
 


### PR DESCRIPTION
## Description

This PR partially resolves issue # [20](https://github.com/supermacro/elm-antd/issues/20)

The PR adds ellie example links only to Button, Tooltip and Typography examples, since Icon, Layout, Menu and Space pages are not yet implemented.

## Action Items

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] This PR is as small as it can be, and only implements on thing (not many)
- [x] I have manually tested my feature
- [ ] I have written a "good" amount of tests (including visual and unit tests) - Tests not needed

