### PR TITLE
Fixed elm-package typo in Showcase

### DIFF
--- a/showcase/src/elm/Routes/Home.elm
+++ b/showcase/src/elm/Routes/Home.elm
@@ -18,7 +18,7 @@ homePage =
         , documentationSubheading WithoutAnchorLink "Getting Started"
         , documentationText <| codeText "elm install supermacro/elm-antd"
         , documentationSubheading WithoutAnchorLink "API Docs"
-        , link "https://package.elm-lang.org/packages/supermacro/elm-antd/latest/" "package.elm-lange.org"
+        , link "https://package.elm-lang.org/packages/supermacro/elm-antd/latest/" "package.elm-lang.org"
         , documentationSubheading WithoutAnchorLink "Currently Implemented Components"
         , documentationUnorderedList
             [ internalLink "/components/button" "Button"


### PR DESCRIPTION
## Description

Hi Supermacro! I noticed a small typo in the Showcase, where you link the elm-package docs.

I plan on contributing some more to this repository during Hacktoberfest after some of my midterms, so I guess you can count this as my first "typo" submission :PP.

## Action Items

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] This PR is as small as it can be, and only implements on thing (not many)
- [x] I have manually tested my feature
- I have written a "good" amount of tests (including visual and unit tests) (not applicable)